### PR TITLE
AppVeyor: Change release description to fit Travis binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ before_deploy:
   - appveyor PushArtifact ../%PROJECT_NAME%-%APPVEYOR_REPO_TAG_NAME%-%TARGET%.zip
 
 deploy:
-  description: 'Windows release'
+  description: 'Automatically deployed release'
   # All the zipped artifacts will be deployed
   artifact: /.*\.zip/
   auth_token:


### PR DESCRIPTION
That will avoid all your future automatically deployed releases being described as "Windows release" when they contain binaries for Linux, OSX and Windows.
